### PR TITLE
[FIX] missing default language when calling to export .pot file

### DIFF
--- a/spp_demo/__manifest__.py
+++ b/spp_demo/__manifest__.py
@@ -29,6 +29,7 @@
     ],
     "external_dependencies": {"python": ["faker"]},
     "data": [
+        "data/res_lang_data.xml",
         "security/ir.model.access.csv",
         "views/generate_data_view.xml",
         "views/generate_program_view.xml",

--- a/spp_demo/data/res_lang_data.xml
+++ b/spp_demo/data/res_lang_data.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="base.lang_en" model="res.lang">
+        <field name="active" eval="True" />
+    </record>
+
+</odoo>


### PR DESCRIPTION
## What this PR does?

Try to fix the error while running test on OCB:

```
2023-02-16 04:12:55,560 3179 ERROR odoo odoo.sql_db: bad query: SELECT res_id, value FROM ir_translation WHERE lang=false AND type='model' AND name='spp.area,name' AND res_id IN (1)
ERROR: operator does not exist: character varying = boolean
```